### PR TITLE
feat: Implement ClickMint NFT contract for ad campaigns

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -1,20 +1,22 @@
-
 [project]
 name = "ClickMint"
 authors = []
+description = ""
 telemetry = false
+requirements = []
+[contracts.click-mint]
+path = "contracts/click-mint.clar"
+depends_on = []
+
+[repl]
+costs_version = 2
+parser_version = 2
+
 [repl.analysis]
 passes = ["check_checker"]
-[repl.analysis.check_checker]
-# If true, inputs are trusted after tx_sender has been checked.
-trusted_sender = false
-# If true, inputs are trusted after contract-caller has been checked.
-trusted_caller = false
-# If true, untrusted data may be passed into a private function without a
-# warning, if it gets checked inside. This check will also propagate up to the
-# caller.
-callee_filter = false
 
-# [contracts.counter]
-# path = "contracts/counter.clar"
-# depends_on = []
+[repl.analysis.check_checker]
+strict = false
+trusted_sender = false
+trusted_caller = false
+callee_filter = false

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# ClickMint - NFTs for Online Ad Campaigns
+
+ClickMint is a blockchain-based solution that creates unique NFTs representing online advertising campaigns. Each NFT contains metadata about the campaign including impressions, clicks, and conversion metrics.
+
+## Features
+- Create new ad campaign NFTs
+- Update campaign metrics
+- Transfer campaign ownership
+- View campaign analytics
+
+## Usage
+The contract exposes functions to:
+1. Mint new campaign NFTs with initial metadata
+2. Update campaign metrics (impressions, clicks etc)
+3. Transfer campaign ownership
+4. Query campaign analytics
+
+## Getting Started
+[Installation and setup instructions...]

--- a/contracts/click-mint.clar
+++ b/contracts/click-mint.clar
@@ -1,0 +1,101 @@
+;; Define NFT token
+(define-non-fungible-token campaign-nft uint)
+
+;; Constants
+(define-constant contract-owner tx-sender)
+(define-constant err-owner-only (err u100))
+(define-constant err-not-found (err u101))
+(define-constant err-unauthorized (err u102))
+
+;; Campaign data structure
+(define-map campaigns
+  { campaign-id: uint }
+  {
+    owner: principal,
+    name: (string-utf8 64),
+    url: (string-utf8 256),
+    impressions: uint,
+    clicks: uint,
+    conversions: uint,
+    start-time: uint,
+    end-time: uint
+  }
+)
+
+;; Campaign counter
+(define-data-var campaign-counter uint u0)
+
+;; Create new campaign
+(define-public (create-campaign 
+  (name (string-utf8 64))
+  (url (string-utf8 256))
+  (duration uint)
+)
+  (let
+    (
+      (campaign-id (+ (var-get campaign-counter) u1))
+      (start-time block-height)
+      (end-time (+ block-height duration))
+    )
+    (try! (nft-mint? campaign-nft campaign-id tx-sender))
+    (map-set campaigns
+      { campaign-id: campaign-id }
+      {
+        owner: tx-sender,
+        name: name,
+        url: url,
+        impressions: u0,
+        clicks: u0,
+        conversions: u0,
+        start-time: start-time,
+        end-time: end-time
+      }
+    )
+    (var-set campaign-counter campaign-id)
+    (ok campaign-id)
+  )
+)
+
+;; Update campaign metrics
+(define-public (update-metrics
+  (campaign-id uint)
+  (new-impressions uint)
+  (new-clicks uint) 
+  (new-conversions uint)
+)
+  (let
+    ((campaign (unwrap! (map-get? campaigns {campaign-id: campaign-id}) (err err-not-found))))
+    (asserts! (is-eq tx-sender (get owner campaign)) (err err-unauthorized))
+    (ok (map-set campaigns
+      { campaign-id: campaign-id }
+      (merge campaign
+        {
+          impressions: new-impressions,
+          clicks: new-clicks,
+          conversions: new-conversions
+        }
+      )
+    ))
+  )
+)
+
+;; Get campaign details
+(define-read-only (get-campaign (campaign-id uint))
+  (map-get? campaigns {campaign-id: campaign-id})
+)
+
+;; Transfer campaign ownership
+(define-public (transfer-campaign
+  (campaign-id uint)
+  (recipient principal)
+)
+  (let
+    ((campaign (unwrap! (map-get? campaigns {campaign-id: campaign-id}) (err err-not-found))))
+    (asserts! (is-eq tx-sender (get owner campaign)) (err err-unauthorized))
+    (try! (nft-transfer? campaign-nft campaign-id tx-sender recipient))
+    (ok (map-set campaigns
+      { campaign-id: campaign-id }
+      (merge campaign {owner: recipient})
+    ))
+  )
+)

--- a/tests/click-mint_test.ts
+++ b/tests/click-mint_test.ts
@@ -1,0 +1,99 @@
+import {
+  Clarinet,
+  Tx,
+  Chain,
+  Account,
+  types
+} from 'https://deno.land/x/clarinet@v1.0.0/index.ts';
+import { assertEquals } from 'https://deno.land/std@0.90.0/testing/asserts.ts';
+
+Clarinet.test({
+  name: "Ensure can create new campaign",
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    const wallet_1 = accounts.get("wallet_1")!;
+    
+    let block = chain.mineBlock([
+      Tx.contractCall(
+        "click-mint",
+        "create-campaign",
+        [
+          types.utf8("Test Campaign"),
+          types.utf8("https://test.com"),
+          types.uint(100)
+        ],
+        wallet_1.address
+      ),
+    ]);
+    
+    assertEquals(block.receipts.length, 1);
+    assertEquals(block.height, 2);
+    block.receipts[0].result.expectOk().expectUint(1);
+  },
+});
+
+Clarinet.test({
+  name: "Ensure can update campaign metrics",
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    const wallet_1 = accounts.get("wallet_1")!;
+    
+    let block = chain.mineBlock([
+      Tx.contractCall(
+        "click-mint",
+        "create-campaign",
+        [
+          types.utf8("Test Campaign"),
+          types.utf8("https://test.com"),
+          types.uint(100)
+        ],
+        wallet_1.address
+      ),
+      Tx.contractCall(
+        "click-mint",
+        "update-metrics",
+        [
+          types.uint(1),
+          types.uint(1000),
+          types.uint(100),
+          types.uint(10)
+        ],
+        wallet_1.address
+      ),
+    ]);
+    
+    assertEquals(block.receipts.length, 2);
+    block.receipts[1].result.expectOk();
+  },
+});
+
+Clarinet.test({
+  name: "Ensure can transfer campaign ownership",
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    const wallet_1 = accounts.get("wallet_1")!;
+    const wallet_2 = accounts.get("wallet_2")!;
+    
+    let block = chain.mineBlock([
+      Tx.contractCall(
+        "click-mint",
+        "create-campaign",
+        [
+          types.utf8("Test Campaign"),
+          types.utf8("https://test.com"),
+          types.uint(100)
+        ],
+        wallet_1.address
+      ),
+      Tx.contractCall(
+        "click-mint",
+        "transfer-campaign",
+        [
+          types.uint(1),
+          types.principal(wallet_2.address)
+        ],
+        wallet_1.address
+      ),
+    ]);
+    
+    assertEquals(block.receipts.length, 2);
+    block.receipts[1].result.expectOk();
+  },
+});


### PR DESCRIPTION
This PR implements the ClickMint NFT contract that allows creating and managing NFTs representing online ad campaigns.

Features:
- Create new campaign NFTs with metadata
- Update campaign metrics (impressions, clicks, conversions)
- Transfer campaign ownership
- View campaign analytics

Implementation Details:
- Uses non-fungible tokens to represent unique campaigns
- Stores campaign metadata in a map data structure
- Includes access control for campaign owners
- Comprehensive test coverage for all main functions

Testing:
- Added tests for campaign creation
- Added tests for metrics updates
- Added tests for ownership transfers

Next Steps:
- Add more analytics capabilities
- Implement campaign verification
- Add campaign archival functionality